### PR TITLE
Update settings.html

### DIFF
--- a/src/settings.html
+++ b/src/settings.html
@@ -1,6 +1,7 @@
 <style>
     /* 背景颜色透明度滑条 */
     .mspring_theme input[type='range']::-webkit-slider-thumb {
+	margin-top: -8px;
         -webkit-appearance: none;
         height: 16px;
         width: 16px;
@@ -44,7 +45,7 @@
                         之后不会生效</setting-text>
                 </div>
                 <input type="range" value="1" min="0" max="100" step="1"
-                    class="q-button q-button--small q-button--secondary pick-opacity" style="width: 61%;" />
+                    class="q-button q-button--small q-button--secondary pick-opacity" style="width: 61%; height:25px;" />
             </setting-item>
             <setting-item data-direction="row">
                 <div>


### PR DESCRIPTION
作者，您好，在今天更新[LiteLoaderQQNT-MSpring-Theme](https://github.com/MUKAPP/LiteLoaderQQNT-MSpring-Theme)插件之后 我发现了如下两个问题：
1. 调整背景颜色透明度的按钮不在滑动条上
2. 滑动条高度和滑动按钮差距过大
 因为我并不太了解 具体功能是怎么样实现的，我只能通过调整Update settings.html 界面中的一些代码将 效果 调整为更合适的状态