### PR TITLE
联系人页面上方 好友通知、群通知圆角；任务栏消息通知列表项目

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -56,10 +56,17 @@ html:not(.mspring_background_plugin_enabled) .tab-container .two-col-layout__mai
 .sys-notify__container .list-item {
     border-radius: 8px;
 }
-
+/*适用于较新版本的QQNT*/
+.notify-option {
+    border-radius: 8px; 
+}
 /* 消息列表项圆角 */
 .recent-contact-item {
     border-radius: 12px;
+}
+/* 把任务栏QQ图标上方的消息通知消息内容加入圆角 */
+.msg-list .list-item.across-mode.msg-list-item {
+    border-radius: 10px; /* 可以根据需要调整圆角的大小 */
 }
 
 /* 联系人列表项圆角 */
@@ -144,12 +151,11 @@ html:is(.linux) .container .more-panel .side-panel {
 }
 
 
-/* 好友通知、群通知列表项 */
+/* cc*/
 .sys-notify__container .sys-notify-card {
     background: var(--msp-container);
 }
-
-/* 搜索结果 */
+.notify-op/
 .search-result {
     border-radius: 12px 12px 0px 0px;
     backdrop-filter: blur(32px) saturate(150%) opacity(40%);

--- a/src/style.css
+++ b/src/style.css
@@ -56,17 +56,20 @@ html:not(.mspring_background_plugin_enabled) .tab-container .two-col-layout__mai
 .sys-notify__container .list-item {
     border-radius: 8px;
 }
-/*适用于较新版本的QQNT*/
+
+/* 联系人页面上方 好友通知、群通知 */
 .notify-option {
     border-radius: 8px; 
 }
+
 /* 消息列表项圆角 */
 .recent-contact-item {
     border-radius: 12px;
 }
-/* 把任务栏QQ图标上方的消息通知消息内容加入圆角 */
+
+/* 任务栏消息通知列表项目 */
 .msg-list .list-item.across-mode.msg-list-item {
-    border-radius: 10px; /* 可以根据需要调整圆角的大小 */
+    border-radius: 8px;
 }
 
 /* 联系人列表项圆角 */
@@ -150,12 +153,12 @@ html:is(.linux) .container .more-panel .side-panel {
     background-color: var(--msp-container);
 }
 
-
-/* cc*/
+/* 好友通知、群通知列表项 */
 .sys-notify__container .sys-notify-card {
     background: var(--msp-container);
 }
-.notify-op/
+
+/* 搜索结果 */
 .search-result {
     border-radius: 12px 12px 0px 0px;
     backdrop-filter: blur(32px) saturate(150%) opacity(40%);


### PR DESCRIPTION
1.联系人界面 好友通知 群通知 选项新版本QQNT更改了样式代码  导致之前旧版本的圆角样式文件不可用 加入一行代码之后效果成功展示
2.把任务栏QQ图标上方的消息通知消息内容加入圆角，让其和MSpring-Theme插件的整体样式文件统一